### PR TITLE
Specify encoding for a pod warning

### DIFF
--- a/lib/Plack/Test/Agent.pm
+++ b/lib/Plack/Test/Agent.pm
@@ -139,6 +139,8 @@ package
 
 __END__
 
+=encoding utf-8
+
 =head2 SYNOPSIS
 
     use Test::More;


### PR DESCRIPTION
I got following a warning when I see POD of this module.

```
% perldoc Plack::Test::Agent 
Wide character in print at /home/syohei/.plenv/versions/5.20.1/lib/perl5/5.20.1/Pod/Text.pm line 286.
```

[This line](https://github.com/maxmind/Plack-Test-Agent/blob/master/lib/Plack/Test/Agent.pm#L248) causes this warning.
