### PR TITLE
Adding cookie jar capability to non-server usage (and test and doc)

### DIFF
--- a/t/cookie.t
+++ b/t/cookie.t
@@ -7,14 +7,21 @@ use Test::More;
 use Plack::Test::Agent;
 use HTTP::Cookies;
 
-my $app = sub
-{
+my $app = sub {
     return
+    $_[0]->{REQUEST_URI} eq '/' ?
     [
         200,
         [
             'Content-Type' => 'text/html',
             'Set-Cookie'   => "ID=123; path=/"
+        ],
+        [ "Hi" ]
+    ] :
+    [
+        200,
+        [
+            'Content-Type' => 'text/html',
         ],
         [ "Hi" ]
     ];
@@ -31,5 +38,8 @@ $cookie_jar->scan( sub { @cookies = @_ });
 
 ok @cookies;
 is $cookies[1], 'ID';
+
+my $ares   = $agent->get( '/a' );
+is $ares->request->header('cookie'), 'ID=123';
 
 done_testing;


### PR DESCRIPTION
Previously there was no cookie jar for the non WWW::Mechanize usage case, this patch adds this functionality (and tests for it)